### PR TITLE
queue handlers fixing - PUT requests were processed as GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Limero is now ready to use ✨
 ## 🌀 Quick start
 First, create a queue:
 ```shell
-curl -LX PUT "http://127.0.0.1:7920/queue?name=helloworld" 
+curl -X PUT "http://127.0.0.1:7920/queue?name=helloworld" 
 
 {
 	"ok": true,
@@ -53,14 +53,14 @@ curl --request POST \
 
 And now we will receive a message from the queue:
 ```shell
-curl -LX GET "http://127.0.0.1:7920/msg?qname=helloworld"
+curl -X GET "http://127.0.0.1:7920/msg?qname=helloworld"
 
 {"value":"this is a new message!"}⏎
 ```
 ## 📃 Docs
 To view all the documentation, open the address under the "docs" key in the browser:
 ```shell
-curl -LX GET "http://127.0.0.1:7920/"
+curl -X GET "http://127.0.0.1:7920/"
 
 {
 	"limero": "Welcome!",
@@ -78,7 +78,7 @@ By opening the url in the browser, you can view the full swagger documentation
 ## 🌟 Tips
 You can allocate the queue size in advance if you know the average number of messages that will be in the queue. This will increase the queue performance ⚡
 ```shell
-curl -LX PUT "http://127.0.0.1:7920/queue?name=helloworld&size=100" 
+curl -X PUT "http://127.0.0.1:7920/queue?name=helloworld&size=100" 
 
 {
 	"ok": true,

--- a/internal/server/handlers/queue.go
+++ b/internal/server/handlers/queue.go
@@ -11,19 +11,25 @@ import (
 
 var queues = make(map[string]*queue.Queue)
 
-func Queue(w http.ResponseWriter, r *http.Request) {
+func ActionOnQueueHandlers(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPut:
 		createQueue(w, r)
 	case http.MethodDelete:
 		deleteQueue(w, r)
-	case http.MethodGet:
+	default:
+		response.Send(w, http.StatusMethodNotAllowed, response.Error{Error: "method_not_allowed", Info: "Only PUT, DELETE methods"})
+	}
+}
+
+func InfoAboutQueueHandlers(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
 		if len(r.URL.Path[len("/queue/"):]) > 0 {
 			queueInfo(w, r)
 		} else {
 			Queues(w, r)
 		}
-	default:
+	} else {
 		response.Send(w, http.StatusMethodNotAllowed, response.Error{Error: "method_not_allowed", Info: "Only PUT, DELETE methods"})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,8 @@ func Serv(zlog *zap.Logger) {
 
 	mux.HandleFunc("/", handlers.Root)
 	mux.HandleFunc("/ping", handlers.Ping)
-	mux.HandleFunc("/queue/", handlers.Queue)
+	mux.HandleFunc("/queue", handlers.ActionOnQueueHandlers)
+	mux.HandleFunc("/queue/", handlers.InfoAboutQueueHandlers)
 	mux.HandleFunc("/msg", handlers.Msg)
 
 	loggedMux := logger.LoggerMiddleware(zlog)(mux)


### PR DESCRIPTION
PUT requests were processed as GET because of the "/" in the HandleFunc pattern.

To fix this, the methods for GET are rendered in separate handlers